### PR TITLE
Fixes tabbing through open menu

### DIFF
--- a/app/_includes/mailchimp-subscribe.html
+++ b/app/_includes/mailchimp-subscribe.html
@@ -10,7 +10,7 @@
   </div>
 
     <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;"><input type="text" name="b_94c5a4b768054f20f78d0056a_d1f74d03dd" tabindex="-1" value=""></div>
+    <div style="position: absolute; left: -5000px;"><input id="mce-hidden-input" type="text" name="b_94c5a4b768054f20f78d0056a_d1f74d03dd" tabindex="-1" value=""></div>
 
   <div class="NewsletterForm-submit">
     <input type="submit" class="Btn {{ include.btnClass }}" value="Subscribe" name="subscribe" id="mc-embedded-subscribe">

--- a/app/js/nav.js
+++ b/app/js/nav.js
@@ -2,16 +2,16 @@ $(function() {
   'use strict';
 
   var ESCAPE_CODE = 27;
+  var TAB_CODE = 9;
 
   var $document = $(document);
   var $nav = $('#Nav');
   var $btn = $('#BurgerBtn');
-  $document.on('scroll', setNavClass);
-  $btn.on('click', toggleMenuWithoutPropagation);
-  $nav.on('click', '.NavContent a', toggleMenu);
-  $nav.on('keydown', handleLeaveMenu);
+  var $firstFocusableElement = $btn;
+  var $lastFocusableElement = $('.NavContent-bottom .NavContent-item:last-child');
   setNavClass();
   setOverlayState();
+  setupListeners();
 
   function setNavClass(event) {
     var scroll = $document.scrollTop();
@@ -50,6 +50,7 @@ $(function() {
     if ($btn.hasClass('BurgerBtn--open')) {
       $('.Nav-overlay').attr('aria-hidden', 'false');
       $('a, input', '.Nav-overlay').attr('tabindex', '0');
+      $('#mce-hidden-input').attr('tabindex', '-1');
       $('.Nav-overlay a').first().focus();
       $btn.removeAttr('aria-labelledby');
     } else {
@@ -59,10 +60,42 @@ $(function() {
     }
   }
 
-  function handleLeaveMenu() {
+  function setupListeners() {
+    $document.on('scroll', setNavClass);
+    $btn.on('click', toggleMenuWithoutPropagation);
+    $nav.on('click', '.NavContent a', toggleMenu);
+
+    $btn.on('menu-opened', function() {
+      $nav.on('keydown', handleLeaveMenu);
+      $lastFocusableElement.on('keydown', trapTab);
+      $firstFocusableElement.on('keydown', trapShiftTab);
+    });
+
+    $btn.on('menu-closed', function() {
+      $nav.off('keydown');
+      $lastFocusableElement.off('keydown');
+      $firstFocusableElement.off('keydown');
+    });
+  }
+
+  function handleLeaveMenu(event) {
     if (event.keyCode === ESCAPE_CODE) {
       toggleMenuWithoutPropagation(event);
       $btn.focus();
+    }
+  }
+
+  function trapTab(event) {
+    if(event.keyCode === TAB_CODE) {
+      event.preventDefault();
+      $firstFocusableElement.focus();
+    }
+  }
+
+  function trapShiftTab(event) {
+    if(event.keyCode === TAB_CODE && event.shiftKey) {
+      event.preventDefault();
+      $lastFocusableElement.focus();
     }
   }
 });

--- a/app/js/scene.js
+++ b/app/js/scene.js
@@ -73,7 +73,6 @@
       ease: 'easeInOut'
     })
 
-    console.log(getUrlParameter('no-anim'));
     if ($document.scrollTop() > 100
         || getUrlParameter('no-anim')
         || $('.Nav').hasClass('Nav--alwaysOpaque')) {


### PR DESCRIPTION
- Traps TAB on last focusable element to prevent getting out of menu
- Traps SHIFT+TAB on first focusable element to prevent getting out of
  menu
- Fixes tabindex issue with mce hidden input
- Only setup keyboard event listeners when menu is opened
- Remove all keyboard listeners when menu closes to prevent strange
  behaviour on the rest of the site
