### PR TITLE
Fix nav links color

### DIFF
--- a/app/_sass/components/_btn.sass
+++ b/app/_sass/components/_btn.sass
@@ -33,6 +33,7 @@ $btn-ticket-text-color: #9f4c00
   color: $color-white
   background-color: transparent
 .Nav--scrolled,
+.Nav--alwaysOpaque,
 .Nav--open
   .Btn--navLink
     color: $color-white


### PR DESCRIPTION
Old:
<img width="1169" alt="screen shot 2015-08-25 at 09 58 46" src="https://cloud.githubusercontent.com/assets/4236592/9462787/f6981a24-4b0f-11e5-91a5-e545f6075d85.png">

new: 
<img width="1170" alt="screen shot 2015-08-25 at 09 58 58" src="https://cloud.githubusercontent.com/assets/4236592/9462792/fadde9d8-4b0f-11e5-8c9e-d7894851e48f.png">
